### PR TITLE
Reduces size, refactors core and removes dead code and improves API with overloads

### DIFF
--- a/examples/cra/src/containers/container.kitchein-manipulator.ts
+++ b/examples/cra/src/containers/container.kitchein-manipulator.ts
@@ -16,7 +16,7 @@ export async function provideKitchenManipulatorContainer(
   let ksc = new KitchenSizeUIController({
     onKitchenResize: async () => {
       const currentKitchen = await root.providerMap.kitchen()
-      return await root.replaceCointerInstantly("kitchen", () =>
+      return await root.replaceContainerInstantly("kitchen", () =>
         provideUpgradedKitchenContainer(currentKitchen),
       )
     },

--- a/snow-splash/README.md
+++ b/snow-splash/README.md
@@ -265,7 +265,7 @@ kitchen.oven.pizzaCapacity // 4
 
 ### `getContainerSetNew`
 
-### `replaceCointerInstantly`
+### `replaceContainerInstantly`
 
 When containers are updated react is updated too via hooks
 

--- a/snow-splash/README.md
+++ b/snow-splash/README.md
@@ -269,8 +269,6 @@ kitchen.oven.pizzaCapacity // 4
 
 When containers are updated react is updated too via hooks
 
-### `replaceCointerAsync`
-
 ## API documentation React
 
 ### `getContainerSetHooks`

--- a/snow-splash/package.json
+++ b/snow-splash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snow-splash",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "source": "src/index.ts",
   "exports": {

--- a/snow-splash/src/_utils.ts
+++ b/snow-splash/src/_utils.ts
@@ -4,3 +4,12 @@ export type UnPromisify<T> = T extends Promise<infer U> ? U : T
 
 export type GetContainerFormat<ProviderFunction extends (...args: any) => any> =
   UnPromisify<ReturnType<ProviderFunction>>
+
+export function addGetter(object, key, fn: any) {
+  Object.defineProperty(object, key, {
+    get() {
+      return fn()
+    },
+    enumerable: true,
+  })
+}

--- a/snow-splash/src/index.ts
+++ b/snow-splash/src/index.ts
@@ -3,7 +3,6 @@ export { makeRoot, RootContainer } from "./library.root-container"
 export { generateEnsureContainerSet } from "./react/library.generate-ensure-hooks"
 
 export { getContainerSetHooks } from "./react/library.hook-generator"
-export { useBetterGenericContainer } from "./react/library.hooks"
 export { wait } from "./_utils"
 
 export type { GetContainerFormat, UnPromisify } from "./_utils"

--- a/snow-splash/src/library.root-container.ts
+++ b/snow-splash/src/library.root-container.ts
@@ -177,7 +177,7 @@ export class RootContainer<
   /**
    * Clear first, then slowly recreate
    */
-  public async replaceCointerInstantly<T extends keyof R>(
+  public async replaceContainerInstantly<T extends keyof R>(
     key: T,
     containerProvider: R[T],
   ) {

--- a/snow-splash/src/react/library.hook-generator.ts
+++ b/snow-splash/src/react/library.hook-generator.ts
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from "react"
 import { useBetterGenericContainer } from "./library.hooks"
-import { UnPromisify } from "../_utils"
+import { addGetter, UnPromisify } from "../_utils"
 
 type ContainerGetter<
   providerFun extends (...args: any) => any,
@@ -58,22 +58,19 @@ export function getContainerSetHooks<
   >(
     providerMap: ContMap,
     //@ts-ignore
-    root2: RootContainer,
+    appRoot: RootContainer,
   ) {
     // let root2 = useRoot()
     let FFF = <ContainerGetter>{}
-    for (let contKey of root2.tokens) {
-      Object.defineProperty(FFF, contKey, {
-        get() {
-          return useBetterGenericContainer(() => root2.containers[contKey], {
-            // @ts-expect-error
-            subscribeFunction: (cb: () => any) =>
-              root2.subscribeToContiner(contKey, cb),
-            containerKey: contKey,
-          })
-        },
-        configurable: true,
-      })
+    for (let contKey of appRoot.tokens) {
+      addGetter(FFF, contKey, () =>
+        useBetterGenericContainer(
+          () => appRoot.containers[contKey],
+          //@ts-expect-error
+          (cb: () => any) => appRoot.subscribeToContiner(contKey, cb),
+          contKey,
+        ),
+      )
     }
 
     return FFF
@@ -113,10 +110,7 @@ export function getContainerSetHooks<
 
     return all
   }
-  let m: AppContanier = 1 as any
   return {
-    m,
-    f,
     useRoot: useRoot,
     useContainer: useContainer,
     useContainerSet: useContainerSet,

--- a/snow-splash/src/react/library.hooks.ts
+++ b/snow-splash/src/react/library.hooks.ts
@@ -17,28 +17,19 @@ export type ContainerGenericBettter<T> = [
 
 export function useBetterGenericContainer<T>(
   containerPromise: () => Promise<T>,
-  controls: {
-    onContainerUpdate(cb: (container: T) => void): void
-    unsubscribeFunction?: () => void
-    subscribeFunction?(cb: (container: T) => void): () => void
-    containerKey: string
-  },
+
+  subscribeFunction: (cb: (container: T) => void) => () => void,
+  containerKey: string,
 ): ContainerGenericBettter<T> {
   const [data, setData] = useState<any>(undefined)
   const [error, setError] = useState()
 
   // Update container
   useEffect(() => {
-    if (controls.onContainerUpdate) {
-      controls.onContainerUpdate((container) => {
-        setData(container)
-      })
-      return controls.unsubscribeFunction
+    if (subscribeFunction) {
+      return subscribeFunction((cont) => setData(cont))
     }
-    if (controls.subscribeFunction) {
-      return controls.subscribeFunction((cont) => setData(cont))
-    }
-  }, [controls])
+  }, [subscribeFunction])
 
   // We can add optimizations later.
   useEffect(() => {
@@ -49,5 +40,5 @@ export function useBetterGenericContainer<T>(
       .catch((e) => setError(e))
   }, [])
 
-  return [data, error, controls.containerKey]
+  return [data, error, containerKey]
 }

--- a/snow-splash/tests/container-set-types.spec.ts
+++ b/snow-splash/tests/container-set-types.spec.ts
@@ -17,9 +17,9 @@ it("should check getContainerSet types", async () => {
   expectType<A_Container>(containerSet.aCont)
 })
 
-it("should check getContainerSetNew  types", async () => {
+it("should check getContainerSet function types", async () => {
   const cont = getMainMockAppContainer()
-  let containerSet = await cont.getContainerSetNew((c) => [c.aCont, c.bCont])
+  let containerSet = await cont.getContainerSet((c) => [c.aCont, c.bCont])
   expectNotType<any>(containerSet)
   expectNotType<any>(containerSet.aCont)
   expectType<A_Container>(containerSet.aCont)
@@ -27,7 +27,7 @@ it("should check getContainerSetNew  types", async () => {
 
 it("should check subscribe types", async () => {
   const cont = getMainMockAppContainer()
-  cont.subscribeToContinerSetNew(
+  cont.subscribeToContinerSet(
     (c) => {
       expectNotType<any>(c)
       expectType<"aCont">(c.aCont)

--- a/snow-splash/tests/container-set.spec.ts
+++ b/snow-splash/tests/container-set.spec.ts
@@ -1,5 +1,4 @@
 import { getMainMockAppContainer } from "./mocks/_mock-app-container"
-import { expectType, expectError, printType, expectNotType } from "tsd"
 import { A_Container } from "./mocks/container.a"
 import { B_Container } from "./mocks/container.b"
 
@@ -12,19 +11,6 @@ it("should get two containers that are async", async () => {
   expect(containerSet.bCont.b2).toMatchObject({ a1: {} })
 
   expect(containerSet).toMatchSnapshot(containerSet)
-})
-
-it("should check token types", () => {
-  const cont = getMainMockAppContainer()
-  expectType<("aCont" | "bCont" | "cCont")[]>(cont.tokens)
-})
-
-it("should check getContainerSet types", async () => {
-  const cont = getMainMockAppContainer()
-  let containerSet = await cont.getContainerSet(["aCont", "bCont"])
-  expectNotType<any>(containerSet)
-  expectNotType<any>(containerSet.aCont)
-  expectType<A_Container>(containerSet.aCont)
 })
 
 it("should subscribe to container set change", (cb) => {
@@ -48,43 +34,45 @@ it("should subscribe to container set change", (cb) => {
 it("should get container set via a new API", (cb) => {
   ;(async () => {
     const cont = getMainMockAppContainer()
-    let containerSet = await cont.getContainerSetNew((c) => [c.aCont, c.bCont])
+    let containerSet = await cont.getContainerSet((c) => [c.aCont, c.bCont])
 
     expect(containerSet).toHaveProperty("aCont")
     expect(containerSet).toHaveProperty("bCont")
     expect(containerSet.bCont.b2).toMatchObject({ a1: {} })
     expect(containerSet).toMatchSnapshot(containerSet)
 
-    // test types
-    expectNotType<any>(containerSet)
-    expectNotType<any>(containerSet.aCont)
-    expectType<A_Container>(containerSet.aCont)
-
     cb()
   })()
-})
-
-it("should check containerSet type", async () => {
-  const cont = getMainMockAppContainer()
-  let containerSet = await cont.getContainerSetNew((c) => [c.aCont, c.bCont])
-
-  // test types
-  expectNotType<any>(containerSet)
-  expectNotType<any>(containerSet.aCont)
-  expectType<A_Container>(containerSet.aCont)
 })
 
 it("should subscribe to container set change via a new APi", (cb) => {
   ;(async () => {
     const cont = getMainMockAppContainer()
-    let containerSet = await cont.getContainerSetNew((c) => [c.aCont, c.cCont])
+    let containerSet = await cont.getContainerSet((c) => [c.aCont, c.cCont])
     expect(containerSet).toHaveProperty("aCont")
 
     containerSet.cCont.upgradeCContainer()
-    cont.subscribeToContinerSetNew(
+    cont.subscribeToContinerSet(
       (c) => {
-        expectNotType<any>(c)
-        expectType<"aCont">(c.aCont)
+        return [c.aCont, c.cCont]
+      },
+      (containerSet) => {
+        expect(containerSet.cCont.c2.size).toBe(10)
+        cb()
+      },
+    )
+  })()
+})
+
+it("should subscribe to container set change via a old APi", (cb) => {
+  ;(async () => {
+    const cont = getMainMockAppContainer()
+    let containerSet = await cont.getContainerSet(["aCont", "cCont"])
+    expect(containerSet).toHaveProperty("aCont")
+
+    containerSet.cCont.upgradeCContainer()
+    cont.subscribeToContinerSet(
+      (c) => {
         return [c.aCont, c.cCont]
       },
       (containerSet) => {
@@ -98,17 +86,17 @@ it("should subscribe to container set change via a new APi", (cb) => {
 it("should be able to unsubscribe from container set change", (cb) => {
   ;(async () => {
     const cont = getMainMockAppContainer()
-    let containerSet = await cont.getContainerSetNew((c) => [c.aCont, c.cCont])
+    let containerSet = await cont.getContainerSet((c) => [c.aCont, c.cCont])
 
     const fn = jest.fn()
     containerSet.cCont.upgradeCContainer()
-    const unsub = cont.subscribeToContinerSetNew(
+    const unsub = cont.subscribeToContinerSet(
       (c) => [c.cCont],
       () => {
         unsub()
         fn()
         containerSet.cCont.upgradeCContainer()
-        cont.subscribeToContinerSetNew(
+        cont.subscribeToContinerSet(
           (c) => [c.cCont],
           () => {
             expect(fn).toHaveBeenCalledTimes(1)

--- a/snow-splash/tests/mocks/container.c.ts
+++ b/snow-splash/tests/mocks/container.c.ts
@@ -18,7 +18,7 @@ export async function provideCContainer(
   const c2 = new C2(a.a1, b.b2, 5)
 
   async function replacer(ovenSize = 10) {
-    return await root.replaceCointerInstantly("cCont", async () => {
+    return await root.replaceContainerInstantly("cCont", async () => {
       const c1 = new C1(a.a2)
       const c2 = new C2(a.a1, b.b2, ovenSize)
       return {


### PR DESCRIPTION

before
```
    1.99 kB: snow-splash.cjs.gz
      1.76 kB: snow-splash.cjs.br
       1181 B: snow-splash.modern.js.gz
       1058 B: snow-splash.modern.js.br
      1.98 kB: snow-splash.modern.js.gz
      1.74 kB: snow-splash.modern.js.br
      2.08 kB: snow-splash.umd.js.gz
      1.83 kB: snow-splash.umd.js.br
```

after
```
  1.86 kB: snow-splash.cjs.gz
      1.65 kB: snow-splash.cjs.br
       1086 B: snow-splash.modern.js.gz
        970 B: snow-splash.modern.js.br
      1.84 kB: snow-splash.modern.js.gz
      1.64 kB: snow-splash.modern.js.br
      1.93 kB: snow-splash.umd.js.gz
      1.71 kB: snow-splash.umd.js.br
```